### PR TITLE
fix(server): FedAvg tuned for single-client (min_* = 1)

### DIFF
--- a/FlowerAI/server/server.py
+++ b/FlowerAI/server/server.py
@@ -7,7 +7,13 @@ ROUNDS = int(os.getenv("FLOWER_NUM_ROUNDS", "3"))
 
 def main() -> None:
     print(f"[FlowerAI] Starting Flower server at {SERVER_ADDRESS} for {ROUNDS} rounds.")
-    strategy = fl.server.strategy.FedAvg()
+    strategy = fl.server.strategy.FedAvg(
+        fraction_fit=1.0,
+        min_fit_clients=int(os.getenv("FLOWER_MIN_FIT_CLIENTS", "1")),
+        fraction_evaluate=1.0,
+        min_evaluate_clients=int(os.getenv("FLOWER_MIN_EVALUATE_CLIENTS", "1")),
+        min_available_clients=int(os.getenv("FLOWER_MIN_AVAILABLE_CLIENTS", "1")),
+    )
     fl.server.start_server(
         server_address=SERVER_ADDRESS,
         config=fl.server.ServerConfig(num_rounds=ROUNDS),


### PR DESCRIPTION
This pull request modifies the Flower server's FedAvg strategy to support single-client configurations. It sets the minimum required clients for fitting, evaluating, and available clients to 1, which is configurable through environment variables. This enhancement allows for greater flexibility in testing and deployment with minimal client requirements.

---

> This pull request was co-created with Cosine Genie

Original Task: [FedDetectPi/q8a10ej9egve](https://cosine.sh/lkmkz3qnwjxx/FedDetectPi/task/q8a10ej9egve)
Author: Walter Mosqueira
