### PR TITLE
fix(client): return num_examples=1 in fit/evaluate to avoid FedAvg div/0

### DIFF
--- a/FlowerAI/client/raspberry_client.py
+++ b/FlowerAI/client/raspberry_client.py
@@ -13,13 +13,13 @@ class PassiveClient(fl.client.NumPyClient):
 
     def fit(self, parameters, config):
         print(f"[FlowerAI][RPi] Fit -> params: {len(parameters)} | sin entrenamiento local")
-        # No entrenamos nada; devolvemos lo recibido y 0 ejemplos
-        return parameters, 0, {}
+        # No entrenamos nada; devolvemos lo recibido y 1 ejemplo para evitar división por cero
+        return parameters, 1, {}
 
     def evaluate(self, parameters, config):
         print("[FlowerAI][RPi] Evaluate -> sin datos locales")
-        # Sin datos: loss=0.0 y 0 ejemplos
-        return 0.0, 0, {}
+        # Sin datos: loss=0.0 y 1 ejemplo para evitar división por cero
+        return 0.0, 1, {}
 
 
 def main() -> None:


### PR DESCRIPTION
This PR modifies the return values in the `fit` and `evaluate` methods of the `raspberry_client.py` file. In both methods, we change the return value for the number of examples from 0 to 1. This change helps to avoid division by zero errors during the Federated Averaging process, ensuring more robust behavior when no local data is available.

---

> This pull request was co-created with Cosine Genie

Original Task: [FedDetectPi/1hedjzmnk9ju](https://cosine.sh/lkmkz3qnwjxx/FedDetectPi/task/1hedjzmnk9ju)
Author: Walter Mosqueira
