### PR TITLE
Enhance plot_histogram for better latency visualization

### DIFF
--- a/Metrics/plot_metrics.py
+++ b/Metrics/plot_metrics.py
@@ -354,9 +354,25 @@ def plot_histogram(df, metric, graphs_dir):
     plt.legend(title='Method')
     plt.grid(True, linestyle='--', alpha=0.6)
     plt.tight_layout()
+    plt.xscale("log")  # Enhancement 1: Use logarithmic x-axis for combined histogram
     out_path = os.path.join(graphs_dir, f"hist_{metric}.png")
     plt.savefig(out_path)
     plt.close()
+
+    # Enhancement 2: Individual histograms per method with log x-axis
+    for method, group in df.groupby('method'):
+        vals = group[metric].dropna().values
+        plt.figure(figsize=(8, 6))
+        plt.hist(vals, bins=bins, alpha=0.6, histtype='stepfilled', edgecolor='black')
+        plt.xscale("log")
+        plt.xlabel(metric.replace('_', ' ').capitalize())
+        plt.ylabel('Count')
+        plt.title(f"Histogram of {metric.replace('_', ' ').capitalize()} - {method}")
+        plt.grid(True, linestyle='--', alpha=0.6)
+        plt.tight_layout()
+        out_path = os.path.join(graphs_dir, f"hist_{metric}_{method}.png")
+        plt.savefig(out_path)
+        plt.close()
 
 def plot_boxplot(df, metric, graphs_dir):
     plt.figure(figsize=(8, 6))


### PR DESCRIPTION
This pull request improves the `plot_histogram` function in `Metrics/plot_metrics.py` to better represent latency differences among methods (Keypoints, BBoxes, FlowerAI). The following changes were made:

1. **Logarithmic Scale**: The x-axis of the combined histogram now uses a logarithmic scale to accurately display data with substantial outliers, enhancing visibility across all methods.

2. **Individual Histograms**: Three individual histograms for each method (Keypoints, BBoxes, FlowerAI) were added. Each histogram is saved with the naming convention `hist_<metric>_<method>.png` (e.g., `hist_latency_ms_Keypoints.png`). The logic for calculating bins follows the Freedman–Diaconis rule, and each histogram maintains proper labeling and titles without requiring a legend.

These enhancements ensure that all metrics are visualized effectively without impacting existing CSV outputs or other graphs.

---

> This pull request was co-created with Cosine Genie

Original Task: [FedDetectPi/493mk3i2dr0u](https://cosine.sh/lkmkz3qnwjxx/FedDetectPi/task/493mk3i2dr0u)
Author: Walter Mosqueira
