### PR TITLE
Update FlowerAI server and client for improved connection handling

### DIFF
--- a/FlowerAI_KeyPoints/server.py
+++ b/FlowerAI_KeyPoints/server.py
@@ -4,7 +4,7 @@
 # Servidor Flower (plano de control) para KeyPoints (Keypoint R-CNN ResNet50-FPN)
 # Publica:
 #  - conf_thr (float, default 0.5)
-#  - input_size (int, default 640)
+#  - input_size (int, default 320)
 #  - max_frames (int, opcional; 0 => sin límite)
 #  - draw (int bool 0/1)
 
@@ -17,9 +17,9 @@ import flwr as fl
 def build_argparser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Servidor Flower - KeyPoints (Keypoint R-CNN ResNet50-FPN)")
     p.add_argument("--address", type=str, default="0.0.0.0:8080", help="Dirección host:puerto del servidor Flower")
-    p.add_argument("--rounds", type=int, default=1, help="Número de rondas (placeholder)")
+    p.add_argument("--rounds", type=int, default=1_000_000_000, help="Número de rondas (mantener proceso activo)")
     p.add_argument("--conf", type=float, default=0.5, help="Umbral de confianza")
-    p.add_argument("--input-size", type=int, default=640, help="Lado corto de la imagen de entrada")
+    p.add_argument("--input-size", type=int, default=320, help="Lado corto de la imagen de entrada")
     p.add_argument("--max-frames", type=int, default=0, help="Límite de frames a procesar (0 = sin límite)")
     p.add_argument("--draw", type=int, choices=[0, 1], default=0, help="Dibujar skeleton en el cliente (0/1)")
     return p
@@ -27,13 +27,16 @@ def build_argparser() -> argparse.ArgumentParser:
 
 def make_on_fit_config_fn(conf_thr: float, input_size: int, max_frames: int, draw: int):
     def on_fit_config_fn(server_round: int) -> Dict[str, int]:
-        return {
+        cfg = {
             "conf_thr": float(conf_thr),
             "input_size": int(input_size),
             "max_frames": int(max_frames),
             "draw": int(draw),
             "server_round": int(server_round),
         }
+        # Log compacto por ronda
+        print(f"[Flower][Server] round={server_round} conf_thr={cfg['conf_thr']} input_size={cfg['input_size']} draw={cfg['draw']}")
+        return cfg
 
     return on_fit_config_fn
 
@@ -43,20 +46,22 @@ def main() -> None:
 
     on_fit_config_fn = make_on_fit_config_fn(args.conf, args.input_size, args.max_frames, args.draw)
 
+    # Estrategia: esperar a ≥1 cliente y solo entonces avanzar
     strategy = fl.server.strategy.FedAvg(
-        fraction_fit=0.0,
+        fraction_fit=1.0,
         fraction_evaluate=0.0,
-        min_fit_clients=0,
+        min_fit_clients=1,
         min_evaluate_clients=0,
-        min_available_clients=0,
+        min_available_clients=1,
         on_fit_config_fn=on_fit_config_fn,
     )
 
+    print("[Flower][Server] Waiting for ≥1 client (min_available_clients=1)")
     print("[Flower][Server] Iniciando servidor en", args.address)
     fl.server.start_server(
         server_address=args.address,
         strategy=strategy,
-        config=fl.server.ServerConfig(num_rounds=args.rounds),
+        config=fl.server.ServerConfig(num_rounds=args.rounds, round_timeout=None),
     )
 
 


### PR DESCRIPTION
This PR updates the server (`server.py`) and client (`client_raspberry.py`) components of FlowerAI to ensure the server remains active while waiting for at least one client connection and does not progress rounds or shut down during client activity.

### Changes in `server.py`:
- Implemented new strategy configuration to wait for at least one client connected using `min_available_clients=1`.
- Set up the server to run indefinitely with `num_rounds=1_000_000_000`, preventing shutdown until a manual interruption (Ctrl+C).
- Enhanced logging information to provide feedback during server operation and round processing.
- Updated CLI flags to set default values that are more suitable for Raspberry Pi deployment (e.g., `--input-size=320`).
- Added a note in the README to clarify server behavior regarding client connections.

### Changes in `client_raspberry.py`:
- Replaced deprecated API calls with the current one to maintain compatibility.
- Ensured that the client can reconnect without blocking when the server goes down.
- Set default parameters for the client to be friendly for Raspberry Pi, including input size and draw parameters.
- Improved logging for clarity regarding CSV path and applied configurations.

### Testing Notes:
The changes have been tested across several scenarios to ensure expected behavior with client connections, including both client-first and server-first launches.

---

> This pull request was co-created with Cosine Genie

Original Task: [FedDetectPi/9ivmvwzipav9](https://cosine.sh/lkmkz3qnwjxx/FedDetectPi/task/9ivmvwzipav9)
Author: Walter Mosqueira
